### PR TITLE
Update generated IP for NiosV code sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/ip/pd_system/nios.ip
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/ip/pd_system/nios.ip
@@ -16,14 +16,14 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendor>Intel Corporation</ipxact:vendor>
   <ipxact:library>nios</ipxact:library>
   <ipxact:name>nios</ipxact:name>
-  <ipxact:version>2.0.0</ipxact:version>
+  <ipxact:version>2.1.0</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -57,10 +57,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -89,10 +89,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>platform_irq_rx</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -136,10 +136,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>instruction_manager</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="axi4" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="axi4" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -343,18 +343,18 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:portMap>
             <ipxact:portMap>
               <ipxact:logicalPort>
-                <ipxact:name>rlast</ipxact:name>
-              </ipxact:logicalPort>
-              <ipxact:physicalPort>
-                <ipxact:name>instruction_manager_rlast</ipxact:name>
-              </ipxact:physicalPort>
-            </ipxact:portMap>
-            <ipxact:portMap>
-              <ipxact:logicalPort>
                 <ipxact:name>rready</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
                 <ipxact:name>instruction_manager_rready</ipxact:name>
+              </ipxact:physicalPort>
+            </ipxact:portMap>
+            <ipxact:portMap>
+              <ipxact:logicalPort>
+                <ipxact:name>rlast</ipxact:name>
+              </ipxact:logicalPort>
+              <ipxact:physicalPort>
+                <ipxact:name>instruction_manager_rlast</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
           </ipxact:portMaps>
@@ -446,10 +446,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>data_manager</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="axi4" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="axi4" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -740,10 +740,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>timer_sw_agent</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1073,6 +1073,10 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendorExtensions>
         <altera:altera_assignments>
           <ipxact:parameters>
+            <ipxact:parameter parameterId="embeddedsw.configuration.hideDevice" type="string">
+              <ipxact:name>embeddedsw.configuration.hideDevice</ipxact:name>
+              <ipxact:value>1</ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="embeddedsw.configuration.isFlash" type="string">
               <ipxact:name>embeddedsw.configuration.isFlash</ipxact:name>
               <ipxact:value>0</ipxact:value>
@@ -1099,10 +1103,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>dm_agent</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -1424,6 +1428,10 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendorExtensions>
         <altera:altera_assignments>
           <ipxact:parameters>
+            <ipxact:parameter parameterId="embeddedsw.configuration.hideDevice" type="string">
+              <ipxact:name>embeddedsw.configuration.hideDevice</ipxact:name>
+              <ipxact:value>1</ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="embeddedsw.configuration.isFlash" type="string">
               <ipxact:name>embeddedsw.configuration.isFlash</ipxact:name>
               <ipxact:value>0</ipxact:value>
@@ -1913,9 +1921,9 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>instruction_manager_rlast</ipxact:name>
+        <ipxact:name>instruction_manager_rready</ipxact:name>
         <ipxact:wire>
-          <ipxact:direction>in</ipxact:direction>
+          <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
@@ -1926,9 +1934,9 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>instruction_manager_rready</ipxact:name>
+        <ipxact:name>instruction_manager_rlast</ipxact:name>
         <ipxact:wire>
-          <ipxact:direction>out</ipxact:direction>
+          <ipxact:direction>in</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
           <ipxact:wireTypeDefs>
             <ipxact:wireTypeDef>
@@ -2565,7 +2573,7 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendor>Intel Corporation</ipxact:vendor>
       <ipxact:library>nios</ipxact:library>
       <ipxact:name>intel_niosv_g</ipxact:name>
-      <ipxact:version>2.0.0</ipxact:version>
+      <ipxact:version>2.1.0</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -2764,6 +2772,11 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>Auto DEVICE_SPEEDGRADE</ipxact:displayName>
           <ipxact:value>2</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="AUTO_BOARD" type="string">
+          <ipxact:name>AUTO_BOARD</ipxact:name>
+          <ipxact:displayName>Auto BOARD</ipxact:displayName>
+          <ipxact:value>default</ipxact:value>
+        </ipxact:parameter>
         <ipxact:parameter parameterId="AUTO_CLK_CLOCK_DOMAIN" type="longint">
           <ipxact:name>AUTO_CLK_CLOCK_DOMAIN</ipxact:name>
           <ipxact:displayName>Auto CLOCK_DOMAIN</ipxact:displayName>
@@ -2899,7 +2912,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:parameter>
         <ipxact:parameter parameterId="embeddedsw.configuration.NiosVTCMVersion" type="string">
           <ipxact:name>embeddedsw.configuration.NiosVTCMVersion</ipxact:name>
-          <ipxact:value>2.0.0</ipxact:value>
+          <ipxact:value>2.1.0</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="embeddedsw.configuration.cpuArchitecture" type="string">
           <ipxact:name>embeddedsw.configuration.cpuArchitecture</ipxact:name>
@@ -2908,10 +2921,6 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:parameter parameterId="embeddedsw.configuration.fpuEnabled" type="string">
           <ipxact:name>embeddedsw.configuration.fpuEnabled</ipxact:name>
           <ipxact:value>0</ipxact:value>
-        </ipxact:parameter>
-        <ipxact:parameter parameterId="embeddedsw.configuration.hideDevice" type="string">
-          <ipxact:name>embeddedsw.configuration.hideDevice</ipxact:name>
-          <ipxact:value>1</ipxact:value>
         </ipxact:parameter>
         <ipxact:parameter parameterId="embeddedsw.configuration.isTimerDevice" type="string">
           <ipxact:name>embeddedsw.configuration.isTimerDevice</ipxact:name>
@@ -2999,7 +3008,7 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalVersion
       {
-         value = "1.0.0";
+         value = "2.0.0";
          type = "String";
       }
    }
@@ -3353,18 +3362,18 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;instruction_manager_rlast&lt;/name&gt;
-                    &lt;role&gt;rlast&lt;/role&gt;
-                    &lt;direction&gt;Input&lt;/direction&gt;
+                    &lt;name&gt;instruction_manager_rready&lt;/name&gt;
+                    &lt;role&gt;rready&lt;/role&gt;
+                    &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC&lt;/vhdlType&gt;
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;instruction_manager_rready&lt;/name&gt;
-                    &lt;role&gt;rready&lt;/role&gt;
-                    &lt;direction&gt;Output&lt;/direction&gt;
+                    &lt;name&gt;instruction_manager_rlast&lt;/name&gt;
+                    &lt;role&gt;rlast&lt;/role&gt;
+                    &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
                     &lt;lowerBound&gt;0&lt;/lowerBound&gt;
                     &lt;vhdlType&gt;STD_LOGIC&lt;/vhdlType&gt;
@@ -3827,6 +3836,10 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;assignments&gt;
                 &lt;assignmentValueMap&gt;
                     &lt;entry&gt;
+                        &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
+                        &lt;value&gt;1&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
                         &lt;key&gt;embeddedsw.configuration.isFlash&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
@@ -4122,6 +4135,10 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;/ports&gt;
             &lt;assignments&gt;
                 &lt;assignmentValueMap&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
+                        &lt;value&gt;1&lt;/value&gt;
+                    &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;embeddedsw.configuration.isFlash&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/ip/pd_system/simple_dma_accelerator.ip
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/ip/pd_system/simple_dma_accelerator.ip
@@ -20,10 +20,10 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clock</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -57,10 +57,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>resetn</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -89,10 +89,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>device_exception_bus</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="conduit" version="23.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="conduit" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="conduit" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -126,10 +126,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>kernel_irqs</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="23.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -177,18 +177,18 @@ https://fpgasoftware.intel.com/eula.-->
       </ipxact:parameters>
     </ipxact:busInterface>
     <ipxact:busInterface>
-      <ipxact:name>avm_mem_gmem0_1_port_0_0_rw</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
+      <ipxact:name>avm_mem_gmem0_1_port_0_0_r</ipxact:name>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
                 <ipxact:name>address</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_address</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_address</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -196,7 +196,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>byteenable</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_byteenable</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_byteenable</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -204,7 +204,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>readdatavalid</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_readdatavalid</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_readdatavalid</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -212,7 +212,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>read</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_read</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_read</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -220,7 +220,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>readdata</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_readdata</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_readdata</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -228,7 +228,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>waitrequest</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_waitrequest</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_waitrequest</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -236,7 +236,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>burstcount</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_burstcount</ipxact:name>
+                <ipxact:name>avm_mem_gmem0_1_port_0_0_r_burstcount</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
           </ipxact:portMaps>
@@ -414,26 +414,21 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>Write wait</ipxact:displayName>
           <ipxact:value>0</ipxact:value>
         </ipxact:parameter>
-        <ipxact:parameter parameterId="enableConcurrentSubordinateAccess" type="longint">
-          <ipxact:name>enableConcurrentSubordinateAccess</ipxact:name>
-          <ipxact:displayName>enableConcurrentSubordinateAccess</ipxact:displayName>
-          <ipxact:value>0</ipxact:value>
-        </ipxact:parameter>
       </ipxact:parameters>
     </ipxact:busInterface>
     <ipxact:busInterface>
-      <ipxact:name>avm_mem_gmem1_2_port_0_0_rw</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
+      <ipxact:name>avm_mem_gmem1_2_port_0_0_w</ipxact:name>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
                 <ipxact:name>address</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_address</ipxact:name>
+                <ipxact:name>avm_mem_gmem1_2_port_0_0_w_address</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -441,7 +436,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>byteenable</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_byteenable</ipxact:name>
+                <ipxact:name>avm_mem_gmem1_2_port_0_0_w_byteenable</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -449,7 +444,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>write</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_write</ipxact:name>
+                <ipxact:name>avm_mem_gmem1_2_port_0_0_w_write</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -457,7 +452,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>writedata</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_writedata</ipxact:name>
+                <ipxact:name>avm_mem_gmem1_2_port_0_0_w_writedata</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -465,7 +460,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>waitrequest</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_waitrequest</ipxact:name>
+                <ipxact:name>avm_mem_gmem1_2_port_0_0_w_waitrequest</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
             <ipxact:portMap>
@@ -473,7 +468,7 @@ https://fpgasoftware.intel.com/eula.-->
                 <ipxact:name>burstcount</ipxact:name>
               </ipxact:logicalPort>
               <ipxact:physicalPort>
-                <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_burstcount</ipxact:name>
+                <ipxact:name>avm_mem_gmem1_2_port_0_0_w_burstcount</ipxact:name>
               </ipxact:physicalPort>
             </ipxact:portMap>
           </ipxact:portMaps>
@@ -651,19 +646,14 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>Write wait</ipxact:displayName>
           <ipxact:value>0</ipxact:value>
         </ipxact:parameter>
-        <ipxact:parameter parameterId="enableConcurrentSubordinateAccess" type="longint">
-          <ipxact:name>enableConcurrentSubordinateAccess</ipxact:name>
-          <ipxact:displayName>enableConcurrentSubordinateAccess</ipxact:displayName>
-          <ipxact:value>0</ipxact:value>
-        </ipxact:parameter>
       </ipxact:parameters>
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>csr_ring_root_avs</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.1"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -939,6 +929,56 @@ https://fpgasoftware.intel.com/eula.-->
           <ipxact:displayName>Write wait</ipxact:displayName>
           <ipxact:value>0</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhFeatureGuid" type="string">
+          <ipxact:name>dfhFeatureGuid</ipxact:name>
+          <ipxact:displayName>Feature GUID</ipxact:displayName>
+          <ipxact:value>0</ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhGroupId" type="int">
+          <ipxact:name>dfhGroupId</ipxact:name>
+          <ipxact:displayName>Group ID</ipxact:displayName>
+          <ipxact:value>0</ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhParameterId" type="string">
+          <ipxact:name>dfhParameterId</ipxact:name>
+          <ipxact:displayName>ID</ipxact:displayName>
+          <ipxact:value></ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhParameterName" type="string">
+          <ipxact:name>dfhParameterName</ipxact:name>
+          <ipxact:displayName>Name</ipxact:displayName>
+          <ipxact:value></ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhParameterVersion" type="string">
+          <ipxact:name>dfhParameterVersion</ipxact:name>
+          <ipxact:displayName>Version</ipxact:displayName>
+          <ipxact:value></ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhParameterData" type="string">
+          <ipxact:name>dfhParameterData</ipxact:name>
+          <ipxact:displayName>Data</ipxact:displayName>
+          <ipxact:value></ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhParameterDataLength" type="string">
+          <ipxact:name>dfhParameterDataLength</ipxact:name>
+          <ipxact:displayName>Data length</ipxact:displayName>
+          <ipxact:value></ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhFeatureMajorVersion" type="int">
+          <ipxact:name>dfhFeatureMajorVersion</ipxact:name>
+          <ipxact:displayName>Feature major version</ipxact:displayName>
+          <ipxact:value>0</ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhFeatureMinorVersion" type="int">
+          <ipxact:name>dfhFeatureMinorVersion</ipxact:name>
+          <ipxact:displayName>Feature minor version</ipxact:displayName>
+          <ipxact:value>0</ipxact:value>
+        </ipxact:parameter>
+        <ipxact:parameter parameterId="dfhFeatureId" type="int">
+          <ipxact:name>dfhFeatureId</ipxact:name>
+          <ipxact:displayName>Feature ID</ipxact:displayName>
+          <ipxact:value>35</ipxact:value>
+        </ipxact:parameter>
       </ipxact:parameters>
       <ipxact:vendorExtensions>
         <altera:altera_assignments>
@@ -1045,7 +1085,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_address</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_address</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1063,7 +1103,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_byteenable</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_byteenable</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1081,7 +1121,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_readdatavalid</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_readdatavalid</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
@@ -1094,7 +1134,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_read</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_read</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
@@ -1107,7 +1147,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_readdata</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_readdata</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
           <ipxact:vectors>
@@ -1125,7 +1165,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_waitrequest</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
@@ -1138,7 +1178,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem0_1_port_0_0_rw_burstcount</ipxact:name>
+        <ipxact:name>avm_mem_gmem0_1_port_0_0_r_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1156,7 +1196,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_address</ipxact:name>
+        <ipxact:name>avm_mem_gmem1_2_port_0_0_w_address</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1174,7 +1214,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_byteenable</ipxact:name>
+        <ipxact:name>avm_mem_gmem1_2_port_0_0_w_byteenable</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1192,7 +1232,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_write</ipxact:name>
+        <ipxact:name>avm_mem_gmem1_2_port_0_0_w_write</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
@@ -1205,7 +1245,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_writedata</ipxact:name>
+        <ipxact:name>avm_mem_gmem1_2_port_0_0_w_writedata</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1223,7 +1263,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_waitrequest</ipxact:name>
+        <ipxact:name>avm_mem_gmem1_2_port_0_0_w_waitrequest</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>in</ipxact:direction>
           <ipxact:vectors></ipxact:vectors>
@@ -1236,7 +1276,7 @@ https://fpgasoftware.intel.com/eula.-->
         </ipxact:wire>
       </ipxact:port>
       <ipxact:port>
-        <ipxact:name>avm_mem_gmem1_2_port_0_0_rw_burstcount</ipxact:name>
+        <ipxact:name>avm_mem_gmem1_2_port_0_0_w_burstcount</ipxact:name>
         <ipxact:wire>
           <ipxact:direction>out</ipxact:direction>
           <ipxact:vectors>
@@ -1591,12 +1631,12 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;/parameters&gt;
         &lt;/interface&gt;
         &lt;interface&gt;
-            &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw&lt;/name&gt;
+            &lt;name&gt;avm_mem_gmem0_1_port_0_0_r&lt;/name&gt;
             &lt;type&gt;avalon&lt;/type&gt;
             &lt;isStart&gt;true&lt;/isStart&gt;
             &lt;ports&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_address&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -1605,7 +1645,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_byteenable&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_byteenable&lt;/name&gt;
                     &lt;role&gt;byteenable&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -1614,7 +1654,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_readdatavalid&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_readdatavalid&lt;/name&gt;
                     &lt;role&gt;readdatavalid&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -1623,7 +1663,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_read&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_read&lt;/name&gt;
                     &lt;role&gt;read&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -1632,7 +1672,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_readdata&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_readdata&lt;/name&gt;
                     &lt;role&gt;readdata&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -1641,7 +1681,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_waitrequest&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_waitrequest&lt;/name&gt;
                     &lt;role&gt;waitrequest&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -1650,7 +1690,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_burstcount&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_burstcount&lt;/name&gt;
                     &lt;role&gt;burstcount&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -1799,20 +1839,16 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;key&gt;writeWaitTime&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
-                    &lt;entry&gt;
-                        &lt;key&gt;enableConcurrentSubordinateAccess&lt;/key&gt;
-                        &lt;value&gt;0&lt;/value&gt;
-                    &lt;/entry&gt;
                 &lt;/parameterValueMap&gt;
             &lt;/parameters&gt;
         &lt;/interface&gt;
         &lt;interface&gt;
-            &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw&lt;/name&gt;
+            &lt;name&gt;avm_mem_gmem1_2_port_0_0_w&lt;/name&gt;
             &lt;type&gt;avalon&lt;/type&gt;
             &lt;isStart&gt;true&lt;/isStart&gt;
             &lt;ports&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_address&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -1821,7 +1857,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_byteenable&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_byteenable&lt;/name&gt;
                     &lt;role&gt;byteenable&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -1830,7 +1866,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_write&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_write&lt;/name&gt;
                     &lt;role&gt;write&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -1839,7 +1875,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_writedata&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_writedata&lt;/name&gt;
                     &lt;role&gt;writedata&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -1848,7 +1884,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_waitrequest&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_waitrequest&lt;/name&gt;
                     &lt;role&gt;waitrequest&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -1857,7 +1893,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_burstcount&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_burstcount&lt;/name&gt;
                     &lt;role&gt;burstcount&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -2004,10 +2040,6 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;writeWaitTime&lt;/key&gt;
-                        &lt;value&gt;0&lt;/value&gt;
-                    &lt;/entry&gt;
-                    &lt;entry&gt;
-                        &lt;key&gt;enableConcurrentSubordinateAccess&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
                 &lt;/parameterValueMap&gt;
@@ -2280,6 +2312,41 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;key&gt;writeWaitTime&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureGuid&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhGroupId&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterId&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterName&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterVersion&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterData&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterDataLength&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureMajorVersion&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureMinorVersion&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureId&lt;/key&gt;
+                        &lt;value&gt;35&lt;/value&gt;
+                    &lt;/entry&gt;
                 &lt;/parameterValueMap&gt;
             &lt;/parameters&gt;
         &lt;/interface&gt;
@@ -2315,27 +2382,34 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/connPtSystemInfos&gt;
 &lt;/systemInfosDefinition&gt;</ipxact:value>
         </ipxact:parameter>
+        <ipxact:parameter parameterId="dflBitArray" type="string">
+          <ipxact:name>dflBitArray</ipxact:name>
+          <ipxact:displayName>dflBitArray</ipxact:displayName>
+          <ipxact:value></ipxact:value>
+        </ipxact:parameter>
       </ipxact:parameters>
     </altera:altera_system_parameters>
     <altera:altera_interface_boundary>
       <altera:interface_mapping altera:name="avm_mem_gmem0_0_port_0_0_rw" altera:internal="simple_dma_accelerator.avm_mem_gmem0_0_port_0_0_rw"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw" altera:internal="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw" altera:type="avalon" altera:dir="start">
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_address" altera:internal="avm_mem_gmem0_1_port_0_0_rw_address"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_burstcount" altera:internal="avm_mem_gmem0_1_port_0_0_rw_burstcount"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_byteenable" altera:internal="avm_mem_gmem0_1_port_0_0_rw_byteenable"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_read" altera:internal="avm_mem_gmem0_1_port_0_0_rw_read"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_readdata" altera:internal="avm_mem_gmem0_1_port_0_0_rw_readdata"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_readdatavalid" altera:internal="avm_mem_gmem0_1_port_0_0_rw_readdatavalid"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw_waitrequest" altera:internal="avm_mem_gmem0_1_port_0_0_rw_waitrequest"></altera:port_mapping>
+      <altera:interface_mapping altera:name="avm_mem_gmem0_1_port_0_0_r" altera:internal="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_r" altera:type="avalon" altera:dir="start">
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_address" altera:internal="avm_mem_gmem0_1_port_0_0_r_address"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_burstcount" altera:internal="avm_mem_gmem0_1_port_0_0_r_burstcount"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_byteenable" altera:internal="avm_mem_gmem0_1_port_0_0_r_byteenable"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_read" altera:internal="avm_mem_gmem0_1_port_0_0_r_read"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_readdata" altera:internal="avm_mem_gmem0_1_port_0_0_r_readdata"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_readdatavalid" altera:internal="avm_mem_gmem0_1_port_0_0_r_readdatavalid"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem0_1_port_0_0_r_waitrequest" altera:internal="avm_mem_gmem0_1_port_0_0_r_waitrequest"></altera:port_mapping>
       </altera:interface_mapping>
+      <altera:interface_mapping altera:name="avm_mem_gmem0_1_port_0_0_rw" altera:internal="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw"></altera:interface_mapping>
       <altera:interface_mapping altera:name="avm_mem_gmem1_1_port_0_0_rw" altera:internal="simple_dma_accelerator.avm_mem_gmem1_1_port_0_0_rw"></altera:interface_mapping>
-      <altera:interface_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw" altera:internal="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw" altera:type="avalon" altera:dir="start">
-        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw_address" altera:internal="avm_mem_gmem1_2_port_0_0_rw_address"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw_burstcount" altera:internal="avm_mem_gmem1_2_port_0_0_rw_burstcount"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw_byteenable" altera:internal="avm_mem_gmem1_2_port_0_0_rw_byteenable"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw_waitrequest" altera:internal="avm_mem_gmem1_2_port_0_0_rw_waitrequest"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw_write" altera:internal="avm_mem_gmem1_2_port_0_0_rw_write"></altera:port_mapping>
-        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw_writedata" altera:internal="avm_mem_gmem1_2_port_0_0_rw_writedata"></altera:port_mapping>
+      <altera:interface_mapping altera:name="avm_mem_gmem1_2_port_0_0_rw" altera:internal="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw"></altera:interface_mapping>
+      <altera:interface_mapping altera:name="avm_mem_gmem1_2_port_0_0_w" altera:internal="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_w" altera:type="avalon" altera:dir="start">
+        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_w_address" altera:internal="avm_mem_gmem1_2_port_0_0_w_address"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_w_burstcount" altera:internal="avm_mem_gmem1_2_port_0_0_w_burstcount"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_w_byteenable" altera:internal="avm_mem_gmem1_2_port_0_0_w_byteenable"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_w_waitrequest" altera:internal="avm_mem_gmem1_2_port_0_0_w_waitrequest"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_w_write" altera:internal="avm_mem_gmem1_2_port_0_0_w_write"></altera:port_mapping>
+        <altera:port_mapping altera:name="avm_mem_gmem1_2_port_0_0_w_writedata" altera:internal="avm_mem_gmem1_2_port_0_0_w_writedata"></altera:port_mapping>
       </altera:interface_mapping>
       <altera:interface_mapping altera:name="clock" altera:internal="simple_dma_accelerator.clock" altera:type="clock" altera:dir="end">
         <altera:port_mapping altera:name="clock" altera:internal="clock"></altera:port_mapping>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/ip/pd_system/uart.ip
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/ip/pd_system/uart.ip
@@ -16,14 +16,14 @@ https://fpgasoftware.intel.com/eula.-->
   <ipxact:vendor>Intel Corporation</ipxact:vendor>
   <ipxact:library>uart</ipxact:library>
   <ipxact:name>uart</ipxact:name>
-  <ipxact:version>19.2.3</ipxact:version>
+  <ipxact:version>19.2.4</ipxact:version>
   <ipxact:busInterfaces>
     <ipxact:busInterface>
       <ipxact:name>clk</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="clock" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="clock" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -57,10 +57,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>reset</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="reset" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="reset" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -89,10 +89,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>avalon_jtag_slave</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -436,10 +436,10 @@ https://fpgasoftware.intel.com/eula.-->
     </ipxact:busInterface>
     <ipxact:busInterface>
       <ipxact:name>irq</ipxact:name>
-      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="23.3"></ipxact:busType>
+      <ipxact:busType vendor="intel" library="intel" name="interrupt" version="23.4"></ipxact:busType>
       <ipxact:abstractionTypes>
         <ipxact:abstractionType>
-          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="23.3"></ipxact:abstractionRef>
+          <ipxact:abstractionRef vendor="intel" library="intel" name="interrupt" version="23.4"></ipxact:abstractionRef>
           <ipxact:portMaps>
             <ipxact:portMap>
               <ipxact:logicalPort>
@@ -653,7 +653,7 @@ https://fpgasoftware.intel.com/eula.-->
       <ipxact:vendor>Intel Corporation</ipxact:vendor>
       <ipxact:library>uart</ipxact:library>
       <ipxact:name>altera_avalon_jtag_uart</ipxact:name>
-      <ipxact:version>19.2.3</ipxact:version>
+      <ipxact:version>19.2.4</ipxact:version>
     </altera:entity_info>
     <altera:altera_module_parameters>
       <ipxact:parameters>
@@ -804,7 +804,7 @@ https://fpgasoftware.intel.com/eula.-->
    {
       datum _originalVersion
       {
-         value = "19.2.1";
+         value = "19.2.3";
          type = "String";
       }
    }

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/pd_system.qsys
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/pd_system.qsys
@@ -279,11 +279,6 @@ https://fpgasoftware.intel.com/eula.-->
         </altera:entity_info>
         <altera:altera_module_parameters>
           <ipxact:parameters>
-            <ipxact:parameter parameterId="bspCpu" type="bit">
-              <ipxact:name>bspCpu</ipxact:name>
-              <ipxact:displayName>BSP CPU</ipxact:displayName>
-              <ipxact:value></ipxact:value>
-            </ipxact:parameter>
             <ipxact:parameter parameterId="componentDefinition" type="string">
               <ipxact:name>componentDefinition</ipxact:name>
               <ipxact:displayName>Component definition</ipxact:displayName>
@@ -549,6 +544,11 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:displayName>HLS file</ipxact:displayName>
               <ipxact:value></ipxact:value>
             </ipxact:parameter>
+            <ipxact:parameter parameterId="liveModuleName" type="string">
+              <ipxact:name>liveModuleName</ipxact:name>
+              <ipxact:displayName>Live Module Name</ipxact:displayName>
+              <ipxact:value></ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
@@ -578,11 +578,6 @@ https://fpgasoftware.intel.com/eula.-->
         </altera:entity_info>
         <altera:altera_module_parameters>
           <ipxact:parameters>
-            <ipxact:parameter parameterId="bspCpu" type="bit">
-              <ipxact:name>bspCpu</ipxact:name>
-              <ipxact:displayName>BSP CPU</ipxact:displayName>
-              <ipxact:value></ipxact:value>
-            </ipxact:parameter>
             <ipxact:parameter parameterId="componentDefinition" type="string">
               <ipxact:name>componentDefinition</ipxact:name>
               <ipxact:displayName>Component definition</ipxact:displayName>
@@ -1416,6 +1411,11 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:displayName>HLS file</ipxact:displayName>
               <ipxact:value></ipxact:value>
             </ipxact:parameter>
+            <ipxact:parameter parameterId="liveModuleName" type="string">
+              <ipxact:name>liveModuleName</ipxact:name>
+              <ipxact:displayName>Live Module Name</ipxact:displayName>
+              <ipxact:value></ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
@@ -1538,11 +1538,6 @@ https://fpgasoftware.intel.com/eula.-->
         </altera:entity_info>
         <altera:altera_module_parameters>
           <ipxact:parameters>
-            <ipxact:parameter parameterId="bspCpu" type="bit">
-              <ipxact:name>bspCpu</ipxact:name>
-              <ipxact:displayName>BSP CPU</ipxact:displayName>
-              <ipxact:value></ipxact:value>
-            </ipxact:parameter>
             <ipxact:parameter parameterId="componentDefinition" type="string">
               <ipxact:name>componentDefinition</ipxact:name>
               <ipxact:displayName>Component definition</ipxact:displayName>
@@ -2360,6 +2355,10 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;assignments&gt;
                     &lt;assignmentValueMap&gt;
                         &lt;entry&gt;
+                            &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
+                            &lt;value&gt;1&lt;/value&gt;
+                        &lt;/entry&gt;
+                        &lt;entry&gt;
                             &lt;key&gt;embeddedsw.configuration.isFlash&lt;/key&gt;
                             &lt;value&gt;0&lt;/value&gt;
                         &lt;/entry&gt;
@@ -2656,6 +2655,10 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;assignments&gt;
                     &lt;assignmentValueMap&gt;
                         &lt;entry&gt;
+                            &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
+                            &lt;value&gt;1&lt;/value&gt;
+                        &lt;/entry&gt;
+                        &lt;entry&gt;
                             &lt;key&gt;embeddedsw.configuration.isFlash&lt;/key&gt;
                             &lt;value&gt;0&lt;/value&gt;
                         &lt;/entry&gt;
@@ -2884,11 +2887,17 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
         &lt;className&gt;intel_niosv_g&lt;/className&gt;
-        &lt;version&gt;2.0.0&lt;/version&gt;
+        &lt;version&gt;2.1.0&lt;/version&gt;
         &lt;displayName&gt;Nios V/g General Purpose Processor Intel FPGA IP&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
         &lt;descriptors&gt;
+            &lt;descriptor&gt;
+                &lt;parameterDefaultValue&gt;&lt;/parameterDefaultValue&gt;
+                &lt;parameterName&gt;AUTO_BOARD&lt;/parameterName&gt;
+                &lt;parameterType&gt;java.lang.String&lt;/parameterType&gt;
+                &lt;systemInfotype&gt;BOARD&lt;/systemInfotype&gt;
+            &lt;/descriptor&gt;
             &lt;descriptor&gt;
                 &lt;parameterDefaultValue&gt;-1&lt;/parameterDefaultValue&gt;
                 &lt;parameterName&gt;AUTO_CLK_CLOCK_DOMAIN&lt;/parameterName&gt;
@@ -3895,6 +3904,10 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;assignments&gt;
                 &lt;assignmentValueMap&gt;
                     &lt;entry&gt;
+                        &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
+                        &lt;value&gt;1&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
                         &lt;key&gt;embeddedsw.configuration.isFlash&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
@@ -4191,6 +4204,10 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;assignments&gt;
                 &lt;assignmentValueMap&gt;
                     &lt;entry&gt;
+                        &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
+                        &lt;value&gt;1&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
                         &lt;key&gt;embeddedsw.configuration.isFlash&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
@@ -4467,6 +4484,11 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:displayName>HLS file</ipxact:displayName>
               <ipxact:value></ipxact:value>
             </ipxact:parameter>
+            <ipxact:parameter parameterId="liveModuleName" type="string">
+              <ipxact:name>liveModuleName</ipxact:name>
+              <ipxact:displayName>Live Module Name</ipxact:displayName>
+              <ipxact:value>nios</ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
@@ -4583,7 +4605,7 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;/entry&gt;
         &lt;entry&gt;
             &lt;key&gt;embeddedsw.configuration.NiosVTCMVersion&lt;/key&gt;
-            &lt;value&gt;2.0.0&lt;/value&gt;
+            &lt;value&gt;2.1.0&lt;/value&gt;
         &lt;/entry&gt;
         &lt;entry&gt;
             &lt;key&gt;embeddedsw.configuration.cpuArchitecture&lt;/key&gt;
@@ -4592,10 +4614,6 @@ https://fpgasoftware.intel.com/eula.-->
         &lt;entry&gt;
             &lt;key&gt;embeddedsw.configuration.fpuEnabled&lt;/key&gt;
             &lt;value&gt;0&lt;/value&gt;
-        &lt;/entry&gt;
-        &lt;entry&gt;
-            &lt;key&gt;embeddedsw.configuration.hideDevice&lt;/key&gt;
-            &lt;value&gt;1&lt;/value&gt;
         &lt;/entry&gt;
         &lt;entry&gt;
             &lt;key&gt;embeddedsw.configuration.isTimerDevice&lt;/key&gt;
@@ -4657,11 +4675,6 @@ https://fpgasoftware.intel.com/eula.-->
         </altera:entity_info>
         <altera:altera_module_parameters>
           <ipxact:parameters>
-            <ipxact:parameter parameterId="bspCpu" type="bit">
-              <ipxact:name>bspCpu</ipxact:name>
-              <ipxact:displayName>BSP CPU</ipxact:displayName>
-              <ipxact:value></ipxact:value>
-            </ipxact:parameter>
             <ipxact:parameter parameterId="componentDefinition" type="string">
               <ipxact:name>componentDefinition</ipxact:name>
               <ipxact:displayName>Component definition</ipxact:displayName>
@@ -4970,6 +4983,11 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:displayName>HLS file</ipxact:displayName>
               <ipxact:value></ipxact:value>
             </ipxact:parameter>
+            <ipxact:parameter parameterId="liveModuleName" type="string">
+              <ipxact:name>liveModuleName</ipxact:name>
+              <ipxact:displayName>Live Module Name</ipxact:displayName>
+              <ipxact:value></ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
@@ -4999,11 +5017,6 @@ https://fpgasoftware.intel.com/eula.-->
         </altera:entity_info>
         <altera:altera_module_parameters>
           <ipxact:parameters>
-            <ipxact:parameter parameterId="bspCpu" type="bit">
-              <ipxact:name>bspCpu</ipxact:name>
-              <ipxact:displayName>BSP CPU</ipxact:displayName>
-              <ipxact:value></ipxact:value>
-            </ipxact:parameter>
             <ipxact:parameter parameterId="componentDefinition" type="string">
               <ipxact:name>componentDefinition</ipxact:name>
               <ipxact:displayName>Component definition</ipxact:displayName>
@@ -5156,12 +5169,12 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;/parameters&gt;
             &lt;/interface&gt;
             &lt;interface&gt;
-                &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw&lt;/name&gt;
+                &lt;name&gt;avm_mem_gmem0_1_port_0_0_r&lt;/name&gt;
                 &lt;type&gt;avalon&lt;/type&gt;
                 &lt;isStart&gt;true&lt;/isStart&gt;
                 &lt;ports&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_address&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_address&lt;/name&gt;
                         &lt;role&gt;address&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;32&lt;/width&gt;
@@ -5170,7 +5183,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_byteenable&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_byteenable&lt;/name&gt;
                         &lt;role&gt;byteenable&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;4&lt;/width&gt;
@@ -5179,7 +5192,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_readdatavalid&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_readdatavalid&lt;/name&gt;
                         &lt;role&gt;readdatavalid&lt;/role&gt;
                         &lt;direction&gt;Input&lt;/direction&gt;
                         &lt;width&gt;1&lt;/width&gt;
@@ -5188,7 +5201,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_read&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_read&lt;/name&gt;
                         &lt;role&gt;read&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;1&lt;/width&gt;
@@ -5197,7 +5210,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_readdata&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_readdata&lt;/name&gt;
                         &lt;role&gt;readdata&lt;/role&gt;
                         &lt;direction&gt;Input&lt;/direction&gt;
                         &lt;width&gt;32&lt;/width&gt;
@@ -5206,7 +5219,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_waitrequest&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_waitrequest&lt;/name&gt;
                         &lt;role&gt;waitrequest&lt;/role&gt;
                         &lt;direction&gt;Input&lt;/direction&gt;
                         &lt;width&gt;1&lt;/width&gt;
@@ -5215,7 +5228,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_burstcount&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_burstcount&lt;/name&gt;
                         &lt;role&gt;burstcount&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;4&lt;/width&gt;
@@ -5368,12 +5381,12 @@ https://fpgasoftware.intel.com/eula.-->
                 &lt;/parameters&gt;
             &lt;/interface&gt;
             &lt;interface&gt;
-                &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw&lt;/name&gt;
+                &lt;name&gt;avm_mem_gmem1_2_port_0_0_w&lt;/name&gt;
                 &lt;type&gt;avalon&lt;/type&gt;
                 &lt;isStart&gt;true&lt;/isStart&gt;
                 &lt;ports&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_address&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_address&lt;/name&gt;
                         &lt;role&gt;address&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;32&lt;/width&gt;
@@ -5382,7 +5395,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_byteenable&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_byteenable&lt;/name&gt;
                         &lt;role&gt;byteenable&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;4&lt;/width&gt;
@@ -5391,7 +5404,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_write&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_write&lt;/name&gt;
                         &lt;role&gt;write&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;1&lt;/width&gt;
@@ -5400,7 +5413,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_writedata&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_writedata&lt;/name&gt;
                         &lt;role&gt;writedata&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;32&lt;/width&gt;
@@ -5409,7 +5422,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_waitrequest&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_waitrequest&lt;/name&gt;
                         &lt;role&gt;waitrequest&lt;/role&gt;
                         &lt;direction&gt;Input&lt;/direction&gt;
                         &lt;width&gt;1&lt;/width&gt;
@@ -5418,7 +5431,7 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                     &lt;/port&gt;
                     &lt;port&gt;
-                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_burstcount&lt;/name&gt;
+                        &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_burstcount&lt;/name&gt;
                         &lt;role&gt;burstcount&lt;/role&gt;
                         &lt;direction&gt;Output&lt;/direction&gt;
                         &lt;width&gt;4&lt;/width&gt;
@@ -6063,12 +6076,12 @@ https://fpgasoftware.intel.com/eula.-->
             &lt;/parameters&gt;
         &lt;/interface&gt;
         &lt;interface&gt;
-            &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw&lt;/name&gt;
+            &lt;name&gt;avm_mem_gmem0_1_port_0_0_r&lt;/name&gt;
             &lt;type&gt;avalon&lt;/type&gt;
             &lt;isStart&gt;true&lt;/isStart&gt;
             &lt;ports&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_address&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -6077,7 +6090,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_byteenable&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_byteenable&lt;/name&gt;
                     &lt;role&gt;byteenable&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -6086,7 +6099,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_readdatavalid&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_readdatavalid&lt;/name&gt;
                     &lt;role&gt;readdatavalid&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -6095,7 +6108,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_read&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_read&lt;/name&gt;
                     &lt;role&gt;read&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -6104,7 +6117,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_readdata&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_readdata&lt;/name&gt;
                     &lt;role&gt;readdata&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -6113,7 +6126,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_waitrequest&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_waitrequest&lt;/name&gt;
                     &lt;role&gt;waitrequest&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -6122,7 +6135,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_rw_burstcount&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem0_1_port_0_0_r_burstcount&lt;/name&gt;
                     &lt;role&gt;burstcount&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -6271,20 +6284,16 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;key&gt;writeWaitTime&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
-                    &lt;entry&gt;
-                        &lt;key&gt;enableConcurrentSubordinateAccess&lt;/key&gt;
-                        &lt;value&gt;0&lt;/value&gt;
-                    &lt;/entry&gt;
                 &lt;/parameterValueMap&gt;
             &lt;/parameters&gt;
         &lt;/interface&gt;
         &lt;interface&gt;
-            &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw&lt;/name&gt;
+            &lt;name&gt;avm_mem_gmem1_2_port_0_0_w&lt;/name&gt;
             &lt;type&gt;avalon&lt;/type&gt;
             &lt;isStart&gt;true&lt;/isStart&gt;
             &lt;ports&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_address&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_address&lt;/name&gt;
                     &lt;role&gt;address&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -6293,7 +6302,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_byteenable&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_byteenable&lt;/name&gt;
                     &lt;role&gt;byteenable&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -6302,7 +6311,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_write&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_write&lt;/name&gt;
                     &lt;role&gt;write&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -6311,7 +6320,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_writedata&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_writedata&lt;/name&gt;
                     &lt;role&gt;writedata&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;32&lt;/width&gt;
@@ -6320,7 +6329,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_waitrequest&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_waitrequest&lt;/name&gt;
                     &lt;role&gt;waitrequest&lt;/role&gt;
                     &lt;direction&gt;Input&lt;/direction&gt;
                     &lt;width&gt;1&lt;/width&gt;
@@ -6329,7 +6338,7 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;terminationValue&gt;0&lt;/terminationValue&gt;
                 &lt;/port&gt;
                 &lt;port&gt;
-                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_rw_burstcount&lt;/name&gt;
+                    &lt;name&gt;avm_mem_gmem1_2_port_0_0_w_burstcount&lt;/name&gt;
                     &lt;role&gt;burstcount&lt;/role&gt;
                     &lt;direction&gt;Output&lt;/direction&gt;
                     &lt;width&gt;4&lt;/width&gt;
@@ -6476,10 +6485,6 @@ https://fpgasoftware.intel.com/eula.-->
                     &lt;/entry&gt;
                     &lt;entry&gt;
                         &lt;key&gt;writeWaitTime&lt;/key&gt;
-                        &lt;value&gt;0&lt;/value&gt;
-                    &lt;/entry&gt;
-                    &lt;entry&gt;
-                        &lt;key&gt;enableConcurrentSubordinateAccess&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
                 &lt;/parameterValueMap&gt;
@@ -6752,6 +6757,41 @@ https://fpgasoftware.intel.com/eula.-->
                         &lt;key&gt;writeWaitTime&lt;/key&gt;
                         &lt;value&gt;0&lt;/value&gt;
                     &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureGuid&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhGroupId&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterId&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterName&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterVersion&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterData&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhParameterDataLength&lt;/key&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureMajorVersion&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureMinorVersion&lt;/key&gt;
+                        &lt;value&gt;0&lt;/value&gt;
+                    &lt;/entry&gt;
+                    &lt;entry&gt;
+                        &lt;key&gt;dfhFeatureId&lt;/key&gt;
+                        &lt;value&gt;35&lt;/value&gt;
+                    &lt;/entry&gt;
                 &lt;/parameterValueMap&gt;
             &lt;/parameters&gt;
         &lt;/interface&gt;
@@ -6807,6 +6847,11 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:displayName>HLS file</ipxact:displayName>
               <ipxact:value></ipxact:value>
             </ipxact:parameter>
+            <ipxact:parameter parameterId="liveModuleName" type="string">
+              <ipxact:name>liveModuleName</ipxact:name>
+              <ipxact:displayName>Live Module Name</ipxact:displayName>
+              <ipxact:value>simple_dma_accelerator</ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
@@ -6836,11 +6881,6 @@ https://fpgasoftware.intel.com/eula.-->
         </altera:entity_info>
         <altera:altera_module_parameters>
           <ipxact:parameters>
-            <ipxact:parameter parameterId="bspCpu" type="bit">
-              <ipxact:name>bspCpu</ipxact:name>
-              <ipxact:displayName>BSP CPU</ipxact:displayName>
-              <ipxact:value></ipxact:value>
-            </ipxact:parameter>
             <ipxact:parameter parameterId="componentDefinition" type="string">
               <ipxact:name>componentDefinition</ipxact:name>
               <ipxact:displayName>Component definition</ipxact:displayName>
@@ -7351,7 +7391,7 @@ https://fpgasoftware.intel.com/eula.-->
     &lt;/boundary&gt;
     &lt;originalModuleInfo&gt;
         &lt;className&gt;altera_avalon_jtag_uart&lt;/className&gt;
-        &lt;version&gt;19.2.3&lt;/version&gt;
+        &lt;version&gt;19.2.4&lt;/version&gt;
         &lt;displayName&gt;JTAG UART Intel FPGA IP&lt;/displayName&gt;
     &lt;/originalModuleInfo&gt;
     &lt;systemInfoParameterDescriptors&gt;
@@ -7968,6 +8008,11 @@ https://fpgasoftware.intel.com/eula.-->
               <ipxact:displayName>HLS file</ipxact:displayName>
               <ipxact:value></ipxact:value>
             </ipxact:parameter>
+            <ipxact:parameter parameterId="liveModuleName" type="string">
+              <ipxact:name>liveModuleName</ipxact:name>
+              <ipxact:displayName>Live Module Name</ipxact:displayName>
+              <ipxact:value>uart</ipxact:value>
+            </ipxact:parameter>
             <ipxact:parameter parameterId="logicalView" type="string">
               <ipxact:name>logicalView</ipxact:name>
               <ipxact:displayName>Logical view</ipxact:displayName>
@@ -8023,7 +8068,7 @@ https://fpgasoftware.intel.com/eula.-->
       </altera:module>
     </altera:modules>
     <altera:connections>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw" altera:end="code_data_ram.s1">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_r" altera:end="code_data_ram.s1">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8044,7 +8089,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw" altera:end="code_data_ram.s1">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_w" altera:end="code_data_ram.s1">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8065,7 +8110,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.data_manager" altera:end="uart.avalon_jtag_slave">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.data_manager" altera:end="uart.avalon_jtag_slave">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x00110040"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8086,7 +8131,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.data_manager" altera:end="simple_dma_accelerator.csr_ring_root_avs">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.data_manager" altera:end="simple_dma_accelerator.csr_ring_root_avs">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x00110100"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8107,7 +8152,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.data_manager" altera:end="nios.dm_agent">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.data_manager" altera:end="nios.dm_agent">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x00100000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8128,7 +8173,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.data_manager" altera:end="code_data_ram.s1">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.data_manager" altera:end="code_data_ram.s1">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8149,7 +8194,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.data_manager" altera:end="nios.timer_sw_agent">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.data_manager" altera:end="nios.timer_sw_agent">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x00110000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8170,7 +8215,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.instruction_manager" altera:end="nios.dm_agent">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.instruction_manager" altera:end="nios.dm_agent">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x00100000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8191,7 +8236,7 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="avalon" altera:version="23.3" altera:start="nios.instruction_manager" altera:end="code_data_ram.s1">
+      <altera:connection altera:kind="avalon" altera:version="23.4" altera:start="nios.instruction_manager" altera:end="code_data_ram.s1">
         <altera:connection_parameter altera:parameter_name="arbitrationPriority" altera:parameter_value="1"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="baseAddress" altera:parameter_value="0x0000"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="defaultConnection" altera:parameter_value="false"></altera:connection_parameter>
@@ -8212,21 +8257,21 @@ https://fpgasoftware.intel.com/eula.-->
         <altera:connection_parameter altera:parameter_name="qsys_mm.syncResets" altera:parameter_value="FALSE"></altera:connection_parameter>
         <altera:connection_parameter altera:parameter_name="qsys_mm.widthAdapterImplementation" altera:parameter_value="GENERIC_CONVERTER"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.3" altera:start="clock_in.out_clk" altera:end="reset_in.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.3" altera:start="clock_in.out_clk" altera:end="nios.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.3" altera:start="clock_in.out_clk" altera:end="uart.clk"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.3" altera:start="clock_in.out_clk" altera:end="code_data_ram.clk1"></altera:connection>
-      <altera:connection altera:kind="clock" altera:version="23.3" altera:start="clock_in.out_clk" altera:end="simple_dma_accelerator.clock"></altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="23.3" altera:start="nios.platform_irq_rx" altera:end="uart.irq">
+      <altera:connection altera:kind="clock" altera:version="23.4" altera:start="clock_in.out_clk" altera:end="reset_in.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.4" altera:start="clock_in.out_clk" altera:end="nios.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.4" altera:start="clock_in.out_clk" altera:end="uart.clk"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.4" altera:start="clock_in.out_clk" altera:end="code_data_ram.clk1"></altera:connection>
+      <altera:connection altera:kind="clock" altera:version="23.4" altera:start="clock_in.out_clk" altera:end="simple_dma_accelerator.clock"></altera:connection>
+      <altera:connection altera:kind="interrupt" altera:version="23.4" altera:start="nios.platform_irq_rx" altera:end="uart.irq">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="0"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="interrupt" altera:version="23.3" altera:start="nios.platform_irq_rx" altera:end="simple_dma_accelerator.kernel_irqs">
+      <altera:connection altera:kind="interrupt" altera:version="23.4" altera:start="nios.platform_irq_rx" altera:end="simple_dma_accelerator.kernel_irqs">
         <altera:connection_parameter altera:parameter_name="irqNumber" altera:parameter_value="1"></altera:connection_parameter>
       </altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.3" altera:start="reset_in.out_reset" altera:end="nios.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.3" altera:start="reset_in.out_reset" altera:end="uart.reset"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.3" altera:start="reset_in.out_reset" altera:end="code_data_ram.reset1"></altera:connection>
-      <altera:connection altera:kind="reset" altera:version="23.3" altera:start="reset_in.out_reset" altera:end="simple_dma_accelerator.resetn"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.4" altera:start="reset_in.out_reset" altera:end="nios.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.4" altera:start="reset_in.out_reset" altera:end="uart.reset"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.4" altera:start="reset_in.out_reset" altera:end="code_data_ram.reset1"></altera:connection>
+      <altera:connection altera:kind="reset" altera:version="23.4" altera:start="reset_in.out_reset" altera:end="simple_dma_accelerator.resetn"></altera:connection>
     </altera:connections>
     <altera:interconnect_requirements></altera:interconnect_requirements>
     <altera:wire_level_connections></altera:wire_level_connections>
@@ -8247,15 +8292,15 @@ https://fpgasoftware.intel.com/eula.-->
         <ipxact:busInterfaces>
           <ipxact:busInterface>
             <ipxact:name>nios.dm_agent</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>code_data_ram.s1</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>nios.instruction_manager</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.4"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="nios.instruction_manager">
                 <ipxact:baseAddress>0x0010_0000</ipxact:baseAddress>
@@ -8264,27 +8309,27 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>uart.avalon_jtag_slave</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>simple_dma_accelerator.csr_ring_root_avs</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>nios.dm_agent</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>code_data_ram.s1</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>nios.timer_sw_agent</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>nios.data_manager</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="axi4" version="23.4"></ipxact:busType>
             <ipxact:master>
               <ipxact:addressSpaceRef addressSpaceRef="nios.data_manager">
                 <ipxact:baseAddress>0x0011_0040</ipxact:baseAddress>
@@ -8293,26 +8338,26 @@ https://fpgasoftware.intel.com/eula.-->
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>code_data_ram.s1</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:name>simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_r</ipxact:name>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw">
+              <ipxact:addressSpaceRef addressSpaceRef="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_r">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
           </ipxact:busInterface>
           <ipxact:busInterface>
             <ipxact:name>code_data_ram.s1</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
           </ipxact:busInterface>
           <ipxact:busInterface>
-            <ipxact:name>simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw</ipxact:name>
-            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.3"></ipxact:busType>
+            <ipxact:name>simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_w</ipxact:name>
+            <ipxact:busType vendor="intel" library="intel" name="avalon" version="23.4"></ipxact:busType>
             <ipxact:master>
-              <ipxact:addressSpaceRef addressSpaceRef="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw">
+              <ipxact:addressSpaceRef addressSpaceRef="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_w">
                 <ipxact:baseAddress>0x0000_0000</ipxact:baseAddress>
               </ipxact:addressSpaceRef>
             </ipxact:master>
@@ -8365,7 +8410,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw</ipxact:name>
+            <ipxact:name>simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_r</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>code_data_ram.s1</ipxact:name>
@@ -8375,7 +8420,7 @@ https://fpgasoftware.intel.com/eula.-->
             </ipxact:segments>
           </ipxact:addressSpace>
           <ipxact:addressSpace>
-            <ipxact:name>simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw</ipxact:name>
+            <ipxact:name>simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_w</ipxact:name>
             <ipxact:segments>
               <ipxact:segment>
                 <ipxact:name>code_data_ram.s1</ipxact:name>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/pd_system.qsys.legacy
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/pd_system.qsys.legacy
@@ -185,7 +185,6 @@ https://fpgasoftware.intel.com/eula.-->
    kind="altera_generic_component"
    version="1.0"
    enabled="1">
-  <parameter name="bspCpu" value="" />
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -431,6 +430,7 @@ https://fpgasoftware.intel.com/eula.-->
 </generationInfoDefinition>]]></parameter>
   <parameter name="hdlParameters"><![CDATA[<hdlParameterDescriptorDefinitionList/>]]></parameter>
   <parameter name="hlsFile" value="" />
+  <parameter name="liveModuleName" value="" />
   <parameter name="logicalView">ip/pd_system/pd_system_clock_in.ip</parameter>
   <parameter name="moduleAssignmentDefinition"><![CDATA[<assignmentDefinition>
     <assignmentValueMap/>
@@ -442,7 +442,6 @@ https://fpgasoftware.intel.com/eula.-->
    kind="altera_generic_component"
    version="1.0"
    enabled="1">
-  <parameter name="bspCpu" value="" />
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -1256,6 +1255,7 @@ https://fpgasoftware.intel.com/eula.-->
 </generationInfoDefinition>]]></parameter>
   <parameter name="hdlParameters"><![CDATA[<hdlParameterDescriptorDefinitionList/>]]></parameter>
   <parameter name="hlsFile" value="" />
+  <parameter name="liveModuleName" value="" />
   <parameter name="logicalView">ip/pd_system/code_data_ram.ip</parameter>
   <parameter name="moduleAssignmentDefinition"><![CDATA[<assignmentDefinition>
     <assignmentValueMap>
@@ -1356,7 +1356,6 @@ https://fpgasoftware.intel.com/eula.-->
   <parameter name="svInterfaceDefinition" value="" />
  </module>
  <module name="nios" kind="altera_generic_component" version="1.0" enabled="1">
-  <parameter name="bspCpu" value="" />
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -2171,6 +2170,10 @@ https://fpgasoftware.intel.com/eula.-->
                 <assignments>
                     <assignmentValueMap>
                         <entry>
+                            <key>embeddedsw.configuration.hideDevice</key>
+                            <value>1</value>
+                        </entry>
+                        <entry>
                             <key>embeddedsw.configuration.isFlash</key>
                             <value>0</value>
                         </entry>
@@ -2467,6 +2470,10 @@ https://fpgasoftware.intel.com/eula.-->
                 <assignments>
                     <assignmentValueMap>
                         <entry>
+                            <key>embeddedsw.configuration.hideDevice</key>
+                            <value>1</value>
+                        </entry>
+                        <entry>
                             <key>embeddedsw.configuration.isFlash</key>
                             <value>0</value>
                         </entry>
@@ -2695,11 +2702,17 @@ https://fpgasoftware.intel.com/eula.-->
     </boundary>
     <originalModuleInfo>
         <className>intel_niosv_g</className>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <displayName>Nios V/g General Purpose Processor Intel FPGA IP</displayName>
     </originalModuleInfo>
     <systemInfoParameterDescriptors>
         <descriptors>
+            <descriptor>
+                <parameterDefaultValue></parameterDefaultValue>
+                <parameterName>AUTO_BOARD</parameterName>
+                <parameterType>java.lang.String</parameterType>
+                <systemInfotype>BOARD</systemInfotype>
+            </descriptor>
             <descriptor>
                 <parameterDefaultValue>-1</parameterDefaultValue>
                 <parameterName>AUTO_CLK_CLOCK_DOMAIN</parameterName>
@@ -3702,6 +3715,10 @@ https://fpgasoftware.intel.com/eula.-->
             <assignments>
                 <assignmentValueMap>
                     <entry>
+                        <key>embeddedsw.configuration.hideDevice</key>
+                        <value>1</value>
+                    </entry>
+                    <entry>
                         <key>embeddedsw.configuration.isFlash</key>
                         <value>0</value>
                     </entry>
@@ -3998,6 +4015,10 @@ https://fpgasoftware.intel.com/eula.-->
             <assignments>
                 <assignmentValueMap>
                     <entry>
+                        <key>embeddedsw.configuration.hideDevice</key>
+                        <value>1</value>
+                    </entry>
+                    <entry>
                         <key>embeddedsw.configuration.isFlash</key>
                         <value>0</value>
                     </entry>
@@ -4261,6 +4282,7 @@ https://fpgasoftware.intel.com/eula.-->
 </generationInfoDefinition>]]></parameter>
   <parameter name="hdlParameters"><![CDATA[<hdlParameterDescriptorDefinitionList/>]]></parameter>
   <parameter name="hlsFile" value="" />
+  <parameter name="liveModuleName" value="nios" />
   <parameter name="logicalView">ip/pd_system/nios.ip</parameter>
   <parameter name="moduleAssignmentDefinition"><![CDATA[<assignmentDefinition>
     <assignmentValueMap>
@@ -4370,7 +4392,7 @@ https://fpgasoftware.intel.com/eula.-->
         </entry>
         <entry>
             <key>embeddedsw.configuration.NiosVTCMVersion</key>
-            <value>2.0.0</value>
+            <value>2.1.0</value>
         </entry>
         <entry>
             <key>embeddedsw.configuration.cpuArchitecture</key>
@@ -4379,10 +4401,6 @@ https://fpgasoftware.intel.com/eula.-->
         <entry>
             <key>embeddedsw.configuration.fpuEnabled</key>
             <value>0</value>
-        </entry>
-        <entry>
-            <key>embeddedsw.configuration.hideDevice</key>
-            <value>1</value>
         </entry>
         <entry>
             <key>embeddedsw.configuration.isTimerDevice</key>
@@ -4433,7 +4451,6 @@ https://fpgasoftware.intel.com/eula.-->
    kind="altera_generic_component"
    version="1.0"
    enabled="1">
-  <parameter name="bspCpu" value="" />
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -4722,6 +4739,7 @@ https://fpgasoftware.intel.com/eula.-->
 </generationInfoDefinition>]]></parameter>
   <parameter name="hdlParameters"><![CDATA[<hdlParameterDescriptorDefinitionList/>]]></parameter>
   <parameter name="hlsFile" value="" />
+  <parameter name="liveModuleName" value="" />
   <parameter name="logicalView">ip/pd_system/pd_system_reset_in.ip</parameter>
   <parameter name="moduleAssignmentDefinition"><![CDATA[<assignmentDefinition>
     <assignmentValueMap/>
@@ -4733,7 +4751,6 @@ https://fpgasoftware.intel.com/eula.-->
    kind="altera_generic_component"
    version="1.0"
    enabled="1">
-  <parameter name="bspCpu" value="" />
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -4883,12 +4900,12 @@ https://fpgasoftware.intel.com/eula.-->
                 </parameters>
             </interface>
             <interface>
-                <name>avm_mem_gmem0_1_port_0_0_rw</name>
+                <name>avm_mem_gmem0_1_port_0_0_r</name>
                 <type>avalon</type>
                 <isStart>true</isStart>
                 <ports>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_address</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_address</name>
                         <role>address</role>
                         <direction>Output</direction>
                         <width>32</width>
@@ -4897,7 +4914,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_byteenable</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_byteenable</name>
                         <role>byteenable</role>
                         <direction>Output</direction>
                         <width>4</width>
@@ -4906,7 +4923,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_readdatavalid</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_readdatavalid</name>
                         <role>readdatavalid</role>
                         <direction>Input</direction>
                         <width>1</width>
@@ -4915,7 +4932,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_read</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_read</name>
                         <role>read</role>
                         <direction>Output</direction>
                         <width>1</width>
@@ -4924,7 +4941,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_readdata</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_readdata</name>
                         <role>readdata</role>
                         <direction>Input</direction>
                         <width>32</width>
@@ -4933,7 +4950,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_waitrequest</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_waitrequest</name>
                         <role>waitrequest</role>
                         <direction>Input</direction>
                         <width>1</width>
@@ -4942,7 +4959,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem0_1_port_0_0_rw_burstcount</name>
+                        <name>avm_mem_gmem0_1_port_0_0_r_burstcount</name>
                         <role>burstcount</role>
                         <direction>Output</direction>
                         <width>4</width>
@@ -5095,12 +5112,12 @@ https://fpgasoftware.intel.com/eula.-->
                 </parameters>
             </interface>
             <interface>
-                <name>avm_mem_gmem1_2_port_0_0_rw</name>
+                <name>avm_mem_gmem1_2_port_0_0_w</name>
                 <type>avalon</type>
                 <isStart>true</isStart>
                 <ports>
                     <port>
-                        <name>avm_mem_gmem1_2_port_0_0_rw_address</name>
+                        <name>avm_mem_gmem1_2_port_0_0_w_address</name>
                         <role>address</role>
                         <direction>Output</direction>
                         <width>32</width>
@@ -5109,7 +5126,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem1_2_port_0_0_rw_byteenable</name>
+                        <name>avm_mem_gmem1_2_port_0_0_w_byteenable</name>
                         <role>byteenable</role>
                         <direction>Output</direction>
                         <width>4</width>
@@ -5118,7 +5135,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem1_2_port_0_0_rw_write</name>
+                        <name>avm_mem_gmem1_2_port_0_0_w_write</name>
                         <role>write</role>
                         <direction>Output</direction>
                         <width>1</width>
@@ -5127,7 +5144,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem1_2_port_0_0_rw_writedata</name>
+                        <name>avm_mem_gmem1_2_port_0_0_w_writedata</name>
                         <role>writedata</role>
                         <direction>Output</direction>
                         <width>32</width>
@@ -5136,7 +5153,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem1_2_port_0_0_rw_waitrequest</name>
+                        <name>avm_mem_gmem1_2_port_0_0_w_waitrequest</name>
                         <role>waitrequest</role>
                         <direction>Input</direction>
                         <width>1</width>
@@ -5145,7 +5162,7 @@ https://fpgasoftware.intel.com/eula.-->
                         <terminationValue>0</terminationValue>
                     </port>
                     <port>
-                        <name>avm_mem_gmem1_2_port_0_0_rw_burstcount</name>
+                        <name>avm_mem_gmem1_2_port_0_0_w_burstcount</name>
                         <role>burstcount</role>
                         <direction>Output</direction>
                         <width>4</width>
@@ -5786,12 +5803,12 @@ https://fpgasoftware.intel.com/eula.-->
             </parameters>
         </interface>
         <interface>
-            <name>avm_mem_gmem0_1_port_0_0_rw</name>
+            <name>avm_mem_gmem0_1_port_0_0_r</name>
             <type>avalon</type>
             <isStart>true</isStart>
             <ports>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_address</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_address</name>
                     <role>address</role>
                     <direction>Output</direction>
                     <width>32</width>
@@ -5800,7 +5817,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_byteenable</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_byteenable</name>
                     <role>byteenable</role>
                     <direction>Output</direction>
                     <width>4</width>
@@ -5809,7 +5826,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_readdatavalid</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_readdatavalid</name>
                     <role>readdatavalid</role>
                     <direction>Input</direction>
                     <width>1</width>
@@ -5818,7 +5835,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_read</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_read</name>
                     <role>read</role>
                     <direction>Output</direction>
                     <width>1</width>
@@ -5827,7 +5844,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_readdata</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_readdata</name>
                     <role>readdata</role>
                     <direction>Input</direction>
                     <width>32</width>
@@ -5836,7 +5853,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_waitrequest</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_waitrequest</name>
                     <role>waitrequest</role>
                     <direction>Input</direction>
                     <width>1</width>
@@ -5845,7 +5862,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem0_1_port_0_0_rw_burstcount</name>
+                    <name>avm_mem_gmem0_1_port_0_0_r_burstcount</name>
                     <role>burstcount</role>
                     <direction>Output</direction>
                     <width>4</width>
@@ -5994,20 +6011,16 @@ https://fpgasoftware.intel.com/eula.-->
                         <key>writeWaitTime</key>
                         <value>0</value>
                     </entry>
-                    <entry>
-                        <key>enableConcurrentSubordinateAccess</key>
-                        <value>0</value>
-                    </entry>
                 </parameterValueMap>
             </parameters>
         </interface>
         <interface>
-            <name>avm_mem_gmem1_2_port_0_0_rw</name>
+            <name>avm_mem_gmem1_2_port_0_0_w</name>
             <type>avalon</type>
             <isStart>true</isStart>
             <ports>
                 <port>
-                    <name>avm_mem_gmem1_2_port_0_0_rw_address</name>
+                    <name>avm_mem_gmem1_2_port_0_0_w_address</name>
                     <role>address</role>
                     <direction>Output</direction>
                     <width>32</width>
@@ -6016,7 +6029,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem1_2_port_0_0_rw_byteenable</name>
+                    <name>avm_mem_gmem1_2_port_0_0_w_byteenable</name>
                     <role>byteenable</role>
                     <direction>Output</direction>
                     <width>4</width>
@@ -6025,7 +6038,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem1_2_port_0_0_rw_write</name>
+                    <name>avm_mem_gmem1_2_port_0_0_w_write</name>
                     <role>write</role>
                     <direction>Output</direction>
                     <width>1</width>
@@ -6034,7 +6047,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem1_2_port_0_0_rw_writedata</name>
+                    <name>avm_mem_gmem1_2_port_0_0_w_writedata</name>
                     <role>writedata</role>
                     <direction>Output</direction>
                     <width>32</width>
@@ -6043,7 +6056,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem1_2_port_0_0_rw_waitrequest</name>
+                    <name>avm_mem_gmem1_2_port_0_0_w_waitrequest</name>
                     <role>waitrequest</role>
                     <direction>Input</direction>
                     <width>1</width>
@@ -6052,7 +6065,7 @@ https://fpgasoftware.intel.com/eula.-->
                     <terminationValue>0</terminationValue>
                 </port>
                 <port>
-                    <name>avm_mem_gmem1_2_port_0_0_rw_burstcount</name>
+                    <name>avm_mem_gmem1_2_port_0_0_w_burstcount</name>
                     <role>burstcount</role>
                     <direction>Output</direction>
                     <width>4</width>
@@ -6199,10 +6212,6 @@ https://fpgasoftware.intel.com/eula.-->
                     </entry>
                     <entry>
                         <key>writeWaitTime</key>
-                        <value>0</value>
-                    </entry>
-                    <entry>
-                        <key>enableConcurrentSubordinateAccess</key>
                         <value>0</value>
                     </entry>
                 </parameterValueMap>
@@ -6475,6 +6484,41 @@ https://fpgasoftware.intel.com/eula.-->
                         <key>writeWaitTime</key>
                         <value>0</value>
                     </entry>
+                    <entry>
+                        <key>dfhFeatureGuid</key>
+                        <value>0</value>
+                    </entry>
+                    <entry>
+                        <key>dfhGroupId</key>
+                        <value>0</value>
+                    </entry>
+                    <entry>
+                        <key>dfhParameterId</key>
+                    </entry>
+                    <entry>
+                        <key>dfhParameterName</key>
+                    </entry>
+                    <entry>
+                        <key>dfhParameterVersion</key>
+                    </entry>
+                    <entry>
+                        <key>dfhParameterData</key>
+                    </entry>
+                    <entry>
+                        <key>dfhParameterDataLength</key>
+                    </entry>
+                    <entry>
+                        <key>dfhFeatureMajorVersion</key>
+                        <value>0</value>
+                    </entry>
+                    <entry>
+                        <key>dfhFeatureMinorVersion</key>
+                        <value>0</value>
+                    </entry>
+                    <entry>
+                        <key>dfhFeatureId</key>
+                        <value>35</value>
+                    </entry>
                 </parameterValueMap>
             </parameters>
         </interface>
@@ -6517,6 +6561,7 @@ https://fpgasoftware.intel.com/eula.-->
 </generationInfoDefinition>]]></parameter>
   <parameter name="hdlParameters"><![CDATA[<hdlParameterDescriptorDefinitionList/>]]></parameter>
   <parameter name="hlsFile" value="" />
+  <parameter name="liveModuleName">simple_dma_accelerator</parameter>
   <parameter name="logicalView">ip/pd_system/simple_dma_accelerator.ip</parameter>
   <parameter name="moduleAssignmentDefinition"><![CDATA[<assignmentDefinition>
     <assignmentValueMap/>
@@ -6524,7 +6569,6 @@ https://fpgasoftware.intel.com/eula.-->
   <parameter name="svInterfaceDefinition" value="" />
  </module>
  <module name="uart" kind="altera_generic_component" version="1.0" enabled="1">
-  <parameter name="bspCpu" value="" />
   <parameter name="componentDefinition"><![CDATA[<componentDefinition>
     <boundary>
         <interfaces>
@@ -7032,7 +7076,7 @@ https://fpgasoftware.intel.com/eula.-->
     </boundary>
     <originalModuleInfo>
         <className>altera_avalon_jtag_uart</className>
-        <version>19.2.3</version>
+        <version>19.2.4</version>
         <displayName>JTAG UART Intel FPGA IP</displayName>
     </originalModuleInfo>
     <systemInfoParameterDescriptors>
@@ -7632,6 +7676,7 @@ https://fpgasoftware.intel.com/eula.-->
 </generationInfoDefinition>]]></parameter>
   <parameter name="hdlParameters"><![CDATA[<hdlParameterDescriptorDefinitionList/>]]></parameter>
   <parameter name="hlsFile" value="" />
+  <parameter name="liveModuleName" value="uart" />
   <parameter name="logicalView">ip/pd_system/uart.ip</parameter>
   <parameter name="moduleAssignmentDefinition"><![CDATA[<assignmentDefinition>
     <assignmentValueMap>
@@ -7673,8 +7718,8 @@ https://fpgasoftware.intel.com/eula.-->
  </module>
  <connection
    kind="avalon"
-   version="23.3"
-   start="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_rw"
+   version="23.4"
+   start="simple_dma_accelerator.avm_mem_gmem0_1_port_0_0_r"
    end="code_data_ram.s1">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x0000" />
@@ -7698,8 +7743,8 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
-   start="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_rw"
+   version="23.4"
+   start="simple_dma_accelerator.avm_mem_gmem1_2_port_0_0_w"
    end="code_data_ram.s1">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x0000" />
@@ -7723,7 +7768,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.data_manager"
    end="uart.avalon_jtag_slave">
   <parameter name="arbitrationPriority" value="1" />
@@ -7748,7 +7793,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.data_manager"
    end="simple_dma_accelerator.csr_ring_root_avs">
   <parameter name="arbitrationPriority" value="1" />
@@ -7773,7 +7818,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.data_manager"
    end="nios.dm_agent">
   <parameter name="arbitrationPriority" value="1" />
@@ -7798,7 +7843,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.data_manager"
    end="code_data_ram.s1">
   <parameter name="arbitrationPriority" value="1" />
@@ -7823,7 +7868,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.data_manager"
    end="nios.timer_sw_agent">
   <parameter name="arbitrationPriority" value="1" />
@@ -7848,7 +7893,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.instruction_manager"
    end="nios.dm_agent">
   <parameter name="arbitrationPriority" value="1" />
@@ -7873,7 +7918,7 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="avalon"
-   version="23.3"
+   version="23.4"
    start="nios.instruction_manager"
    end="code_data_ram.s1">
   <parameter name="arbitrationPriority" value="1" />
@@ -7898,53 +7943,53 @@ https://fpgasoftware.intel.com/eula.-->
  </connection>
  <connection
    kind="clock"
-   version="23.3"
+   version="23.4"
    start="clock_in.out_clk"
    end="reset_in.clk" />
- <connection kind="clock" version="23.3" start="clock_in.out_clk" end="nios.clk" />
- <connection kind="clock" version="23.3" start="clock_in.out_clk" end="uart.clk" />
+ <connection kind="clock" version="23.4" start="clock_in.out_clk" end="nios.clk" />
+ <connection kind="clock" version="23.4" start="clock_in.out_clk" end="uart.clk" />
  <connection
    kind="clock"
-   version="23.3"
+   version="23.4"
    start="clock_in.out_clk"
    end="code_data_ram.clk1" />
  <connection
    kind="clock"
-   version="23.3"
+   version="23.4"
    start="clock_in.out_clk"
    end="simple_dma_accelerator.clock" />
  <connection
    kind="interrupt"
-   version="23.3"
+   version="23.4"
    start="nios.platform_irq_rx"
    end="uart.irq">
   <parameter name="irqNumber" value="0" />
  </connection>
  <connection
    kind="interrupt"
-   version="23.3"
+   version="23.4"
    start="nios.platform_irq_rx"
    end="simple_dma_accelerator.kernel_irqs">
   <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="reset"
-   version="23.3"
+   version="23.4"
    start="reset_in.out_reset"
    end="nios.reset" />
  <connection
    kind="reset"
-   version="23.3"
+   version="23.4"
    start="reset_in.out_reset"
    end="uart.reset" />
  <connection
    kind="reset"
-   version="23.3"
+   version="23.4"
    start="reset_in.out_reset"
    end="code_data_ram.reset1" />
  <connection
    kind="reset"
-   version="23.3"
+   version="23.4"
    start="reset_in.out_reset"
    end="simple_dma_accelerator.resetn" />
 </system>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/test_system.qsf
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/test_system.qsf
@@ -1,7 +1,7 @@
 set_global_assignment -name TOP_LEVEL_ENTITY test_system
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 23.1.0
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "14:34:53  MAY 19, 2023"
-set_global_assignment -name LAST_QUARTUS_VERSION "23.3.0 Pro Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "23.4.0 Pro Edition"
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
 set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
 set_global_assignment -name MAX_CORE_JUNCTION_TEMP 100


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change updates the generated IP for the NiosV code sample due to the changes in port names for the avalonMM in SYCL.

Fixes HSDES #22019827129

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
