### PR TITLE
Update CRR CMakeLists and README

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/CMakeLists.txt
@@ -56,23 +56,32 @@ if(NOT DEFINED DEVICE_FLAG)
 endif()
 
 # Set design parameters according to the selected board
+if (DEFINED SET_OUTER_UNROLL)
+    set(OUTER_UNROLL_V ${SET_OUTER_UNROLL})
+else
+    set(OUTER_UNROLL_V 1)
+endif()
+
+if (DEFINED SET_INNER_UNROLL)
+    set(INNER_UNROLL_V ${SET_INNER_UNROLL})
+else
+    set(INNER_UNROLL_V 64)
+endif()
+
+if (DEFINED SET_OUTER_UNROLL_POW2)
+    set(OUTER_UNROLL_POW2_V ${SET_OUTER_UNROLL_POW2})
+else
+    set(OUTER_UNROLL_POW2_V 1)
+endif()
+
 if(DEVICE_FLAG MATCHES "A10")
     # A10 parameters
-    set(OUTER_UNROLL_V 1)
-    set(INNER_UNROLL_V 64)
-    set(OUTER_UNROLL_POW2_V 1)
     set(SEED "-Xsseed=1")
 elseif(DEVICE_FLAG MATCHES "S10")
     # S10 parameters
-    set(OUTER_UNROLL_V 2)
-    set(INNER_UNROLL_V 64)
-    set(OUTER_UNROLL_POW2_V 2)
     set(SEED "-Xsseed=3")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
     # Agilex 7
-    set(OUTER_UNROLL_V 2)
-    set(INNER_UNROLL_V 64)
-    set(OUTER_UNROLL_POW2_V 2)
     set(SEED "-Xsseed=4")
 else()
     message(FATAL_ERROR "Unknown board!")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/CMakeLists.txt
@@ -58,19 +58,19 @@ endif()
 # Set design parameters according to the selected board
 if (DEFINED SET_OUTER_UNROLL)
     set(OUTER_UNROLL_V ${SET_OUTER_UNROLL})
-else
+else()
     set(OUTER_UNROLL_V 1)
 endif()
 
 if (DEFINED SET_INNER_UNROLL)
     set(INNER_UNROLL_V ${SET_INNER_UNROLL})
-else
+else()
     set(INNER_UNROLL_V 64)
 endif()
 
 if (DEFINED SET_OUTER_UNROLL_POW2)
     set(OUTER_UNROLL_POW2_V ${SET_OUTER_UNROLL_POW2})
-else
+else()
     set(OUTER_UNROLL_POW2_V 1)
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -128,11 +128,11 @@ This design measures the FPGA performance to determine how many assets can be pr
 
 | Flag                    | Description
 |:---                     |:---
-|`-DOUTER_UNROLL=1`       | Uses the value 1 for the constant OUTER_UNROLL, controls the number of CRRs that can be processed in parallel
-|`-DINNER_UNROLL=64`      | Uses the value 64 for the constant INNER_UNROLL, controls the degree of parallelization within the calculation of 1 CRR
-|`-DOUTER_UNROLL_POW2=1`  | Uses the value 1 for the constant OUTER_UNROLL_POW2, controls the number of memory banks
+|`-DSET_OUTER_UNROLL=<N>`       | Sets the value for the constant OUTER_UNROLL to N, controls the number of CRRs that can be processed in parallel. The default value is 1 for all target platforms.
+|`-DSET_INNER_UNROLL=<N>`      | Sets the value for the constant INNER_UNROLL to N, controls the degree of parallelization within the calculation of 1 CRR. The default value is 64 for all target platforms.
+|`-DSET_OUTER_UNROLL_POW2=<N>`  | ets the value for the constant OUTER_UNROLL_POW2 to N, controls the number of memory banks. The default value is 1 for all target platforms.
 
-> **Note**: The `Xsseed`, `DOUTER_UNROLL`, `DINNER_UNROLL`, and `DOUTER_UNROLL_POW2` values differ depending on the board being targeted. You can find more information about the unroll factors in `/src/CRR_common.hpp`.
+> **Note**: The `Xsseed` values differ depending on the board being targeted. You can find more information about the unroll factors in `/src/CRR_common.hpp`.
 
 ## Build the `CRR Binomial Tree` Sample
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Modifies the CMakeLists for the CRR FPGA code sample so that we use the same unroll factors for all platforms and expose the option to modify these unroll factors to the users. The change also updates the readme to reflect these changes.

## External Dependencies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test is now passing on n6001: [SPETC](https://spetc.intel.com/testanalysis?trview=0&testRunIds=10163727&tapgsize=1500)

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used